### PR TITLE
Added support for cleaning up the stale entries in the database

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
+++ b/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import android.content.Context;
 
-import com.frankenstein.screenx.helper.TextHelper;
-import com.frankenstein.screenx.helper.UsageStatsHelper;
 import com.frankenstein.screenx.helper.Logger;
 import com.frankenstein.screenx.models.AppGroup;
 import com.frankenstein.screenx.models.Screenshot;
@@ -155,11 +153,13 @@ public class ScreenFactory {
 
     public void removeScreen(String name) {
         nameToScreen.remove(name);
+        ScreenXApplication.textHelper.deleteScreenshotFromUI(name);
     }
 
     public void removeScreenList(ArrayList<String> toBeRemoved) {
         for (String name: toBeRemoved)
             nameToScreen.remove(toBeRemoved);
+        ScreenXApplication.textHelper.deleteScreenshotListFromUI(toBeRemoved);
     }
 
     public void loadScreens(Context context) {

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
@@ -11,6 +11,9 @@ public interface ScreenShotDao {
     @Query("INSERT INTO ScreenShotEntity (filename, text_content, meta_data) values(:filename, :textContent, :metaData)")
     void putScreenShot(String filename, String textContent, String metaData);
 
+    @Query("UPDATE ScreenShotEntity SET text_content= :textContent WHERE filename = :filename")
+    void updateScreenShotText(String filename, String textContent);
+
     @Query("SELECT * FROM ScreenShotEntity")
     List<ScreenShotEntity> getAll();
 


### PR DESCRIPTION
1.Texthelper will observe the screenshots of screenfactory, and whenever
  there is a change on it, it will trigger a sync mechanism to delete
  the stale entries

Signed-off-by: pavan142 <pa1tirumani@gmail.com>