### PR TITLE
Replaced ad hoc fix of VM Builder with File Provider (for sharing files)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,15 @@
             android:exported="false"
             android:description="@string/service_description"
             android:foregroundServiceType="mediaProjection" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.frankenstein.screenx.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
@@ -19,11 +19,14 @@ import com.frankenstein.screenx.ui.adapters.AppGroupPageAdapter;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.FileProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+
+import static com.frankenstein.screenx.Constants.FILE_PROVIDER_AUTHORITY;
 
 public class AppGroupActivity extends AppCompatActivity {
 
@@ -67,9 +70,6 @@ public class AppGroupActivity extends AppCompatActivity {
         _mAlertBuilder = new AlertDialog.Builder(this);
         ScreenXApplication.screenFactory.screenshots.observe(this, this::postRefresh);
         updateAdapter();
-        // TODO: Find a better fix for this
-        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
-        StrictMode.setVmPolicy(builder.build());
     }
 
 
@@ -171,14 +171,14 @@ public class AppGroupActivity extends AppCompatActivity {
         intent.setType("image/*");
 
         ArrayList<Uri> files = new ArrayList<Uri>();
-
         for(Screenshot screen : _mSelectedScreens) {
             _logger.log("Planning to share", screen.name);
-            Uri uri = Uri.fromFile(screen.file);
+            Uri uri = FileProvider.getUriForFile(this, FILE_PROVIDER_AUTHORITY , screen.file);
             files.add(uri);
         }
 
         intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, files);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         startActivity(intent);
     }
 
@@ -202,7 +202,7 @@ public class AppGroupActivity extends AppCompatActivity {
                             deletedScreens.add(screen.name);
                         _logger.log("Successfully deleted the screenshot", screen.name, screen.appName);
                         } else {
-                        _logger.log("failed to delete the screenshot", screen.name, screen.appName);
+                        _logger.log("Failed to delete the screenshot", screen.name, screen.appName);
                         }
                     }
                     ScreenXApplication.screenFactory.removeScreenList(deletedScreens);

--- a/app/src/main/java/com/frankenstein/screenx/Constants.java
+++ b/app/src/main/java/com/frankenstein/screenx/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
     public static final int TOOLBAR_TRANSITION = 100;
     public static final String DB_NAME="screenshots-db";
     public static final String DB_THREAD_NAME ="db-thread";
+    public static final String FILE_PROVIDER_AUTHORITY="com.frankenstein.screenx.fileprovider";
 }

--- a/app/src/main/java/com/frankenstein/screenx/ScreenActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/ScreenActivity.java
@@ -17,10 +17,12 @@ import com.frankenstein.screenx.models.Screenshot;
 import com.frankenstein.screenx.ui.ImmersiveActivity;
 import com.frankenstein.screenx.ui.adapters.ScreenPageAdapter;
 
+import androidx.core.content.FileProvider;
 import androidx.viewpager.widget.ViewPager;
 
 import java.util.ArrayList;
 
+import static com.frankenstein.screenx.Constants.FILE_PROVIDER_AUTHORITY;
 import static com.frankenstein.screenx.Constants.TOOLBAR_TRANSITION;
 
 public class ScreenActivity extends ImmersiveActivity {
@@ -83,9 +85,6 @@ public class ScreenActivity extends ImmersiveActivity {
         }
 
         updatePager(_currPosition);
-        // TODO: Find a better fix for this
-        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
-        StrictMode.setVmPolicy(builder.build());
     }
 
     private void displayAppGroupItems() {
@@ -146,14 +145,15 @@ public class ScreenActivity extends ImmersiveActivity {
         int position = _viewpager.getCurrentItem();
         Screenshot screen = _screens.get(position);
         _logger.log("ASKED TO SHARE", screen.name, screen.appName);
-        Intent sendIntent = new Intent();
-        sendIntent.setAction(Intent.ACTION_SEND);
-        sendIntent.putExtra(
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_SEND);
+        intent.putExtra(
                 Intent.EXTRA_STREAM,
-                Uri.fromFile(screen.file)
+                FileProvider.getUriForFile(this, FILE_PROVIDER_AUTHORITY, screen.file)
         );
-        sendIntent.setType("image/*");
-        startActivity(Intent.createChooser(sendIntent, "Share Image"));
+        intent.setType("image/*");
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(Intent.createChooser(intent, "Share Image"));
     }
 
     private void alignToolbarWithNavbar() {

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="external_files"
+        path="." />
+    <root-path
+        name="sd_card"
+        path="" />
+</paths>


### PR DESCRIPTION
1. Newer Versions of Android throw an error `FileUriExposedException`
   when generating Uris directly from File for sharing. So Added VM Builder Policy
   to remedy that before this patch.
2. Now declared the app as a file provider in manifest and used
   FileProvider to generate the Uris for a file for sharing.