### PR TITLE
This fixes some of the issues faced due to scoped storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.frankenstein.screenx"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 29
         versionCode 3
         versionName "1.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:icon="@mipmap/gallery_color"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="ocr" />

--- a/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
@@ -182,6 +182,13 @@ public class TextHelper {
     }
 
     public void syncFromUI(ArrayList<Screenshot> screensOnDevice) {
+        if (screensOnDevice.size() == 0) {
+            // There must be an issue with storage permissions or some rogue scenario when this happens, so skipping it
+            // On the other hand, if this is a genuine case, that the user actually deleted all the screenshots on their
+            // phone, then that data will still be retained until a new screenshot appears, when all the old data will be deleted
+            _mLogger.log("ScreensOnDevice is zero!!, has something gone wrong?");
+            return;
+        }
         _mHandler.post(() -> {
             List<ScreenShotEntity> screensOnDatabase = _mDBClient.screenShotDao().getAll();
             ArrayList<String> toBeDeleted = new ArrayList<>();

--- a/app/src/main/java/com/frankenstein/screenx/ui/ScreenXToast.kt
+++ b/app/src/main/java/com/frankenstein/screenx/ui/ScreenXToast.kt
@@ -9,22 +9,6 @@ import android.widget.Toast
 import com.frankenstein.screenx.R
 
 class ScreenXToast(private val context: Context) {
-    companion object {
-
-        /**
-         * Use ScryerToast#show() if you're likely to show toast multiple times within the same page,
-         * so the toast view can be reused instead of inflating a new one each time this method is called.
-         */
-        fun makeText(context: Context, text: String, duration: Int): Toast {
-            val toast = Toast(context)
-            toast.setGravity(Gravity.FILL_HORIZONTAL or Gravity.BOTTOM, 0, 0)
-            toast.view = View.inflate(context, R.layout.custom_toast, null)
-            toast.view?.findViewById<TextView>(R.id.text)?.text = text
-            toast.duration = duration
-            return toast
-        }
-    }
-
     private var toast: Toast? = null
     private var rootView: View = View.inflate(context, R.layout.custom_toast, null)
     private val textView: TextView by lazy {
@@ -36,15 +20,17 @@ class ScreenXToast(private val context: Context) {
         toast?.cancel()
 
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+          // This check is unnecessary , as the target SDK is downgraded from 30 to 29 now
+          // TODO Enable the check once the target SDK is upgraded back to 30
+//        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             toast = Toast(context).apply {
                 setGravity(Gravity.FILL_HORIZONTAL or Gravity.BOTTOM, 0, yOffset)
                 view = rootView
                 duration = toastDuration
                 show()
             }
-        } else {
-            toast = Toast.makeText(context,msg, toastDuration).apply { show() }
-        }
+//        } else {
+//            toast = Toast.makeText(context,msg, toastDuration).apply { show() }
+//        }
     }
 }


### PR DESCRIPTION
This fixes some of the issues faced due to Scoped Storage
    1.  With Android SDK target version 30, scoped storage becomes mandatory, resulting in errors in deleting files on devices with Android 11
    2.  By downgrading the target SDK version to 29, and setting the ```requestLegacyStorage``` in manifest,  scoped storage restriction can be bypassed.
 **Note**:`requestLegacyStorage` is ignored for android  target SDK version >= 30

Closes #44 #34

Signed-off-by: pavan142 <pa1tirumani@gmail.com>