### PR TITLE
Add multiple share and delete functionality to Search Page too

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
@@ -1,73 +1,38 @@
 package com.frankenstein.screenx;
 
-import android.app.AlertDialog;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
-import android.os.StrictMode;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.GridView;
-import android.widget.ImageButton;
 import android.widget.TextView;
 
-import com.frankenstein.screenx.helper.FileHelper;
 import com.frankenstein.screenx.helper.Logger;
 import com.frankenstein.screenx.models.AppGroup;
 import com.frankenstein.screenx.models.Screenshot;
-import com.frankenstein.screenx.ui.adapters.AppGroupPageAdapter;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.FileProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 
-import static com.frankenstein.screenx.Constants.FILE_PROVIDER_AUTHORITY;
+public class AppGroupActivity extends MultipleSelectActivity {
 
-public class AppGroupActivity extends AppCompatActivity {
-
-    private GridView _gridView;
-    private AppGroupPageAdapter _adapter;
     private Logger _logger;
     private String _appName;
+    private TextView _mTextView;
     private SwipeRefreshLayout _pullToRefresh;
     private static final int SCREEN_ACTIVITY_INTENT_CODE = 1;
     private boolean _mPaused = false;
-    private Set<Screenshot> _mSelectedScreens = new HashSet<>();
-    private TextView _mTextView;
-    private ImageButton _mSelectAll;
-    private Toolbar _mToolbar;
-    private View _mSelectActions;
-    private ImageButton _mShare;
-    private ImageButton _mDelete;
-    private ArrayList<Screenshot> _mScreens = new ArrayList<>();
-    private AlertDialog.Builder _mAlertBuilder;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         setContentView(R.layout.appgrouppage);
+        super.onCreate(savedInstanceState);
         _logger = Logger.getInstance("AppGroupActivity");
-        _gridView = findViewById(R.id.grid_view);
         _appName = getIntent().getStringExtra("APP_GROUP_NAME");
         _pullToRefresh = findViewById(R.id.pull_to_refresh);
         _pullToRefresh.setOnRefreshListener(() -> refresh());
-        _mTextView = findViewById(R.id.page_title);
-        _mSelectAll = findViewById(R.id.select_all);
-        _mSelectAll.setOnClickListener(this::onSelectAll);
-        _mToolbar = findViewById(R.id.toolbar);
-        _mToolbar.setNavigationOnClickListener(this::onNavigation);
+        _mTextView = findViewById(R.id.appgrouppage_title);
         _mTextView.setText(_appName);
-        _mSelectActions = findViewById(R.id.select_actions);
-        _mShare = findViewById(R.id.share);
-        _mShare.setOnClickListener(this::onShare);
-        _mDelete = findViewById(R.id.delete);
-        _mDelete.setOnClickListener(this::onDelete);
-        _mAlertBuilder = new AlertDialog.Builder(this);
         ScreenXApplication.screenFactory.screenshots.observe(this, this::postRefresh);
         updateAdapter();
     }
@@ -85,16 +50,17 @@ public class AppGroupActivity extends AppCompatActivity {
     }
 
 
-    private void updateAdapter() {
+    @Override
+    protected void updateAdapter() {
         AppGroup ag = ScreenXApplication.screenFactory.appgroups.get(_appName);
         if (ag == null || ag.screenshots.size() == 0) {
             finish();
             return;
         }
-        boolean sameData = ag.screenshots.size() == _mScreens.size();
+        boolean sameData = ag.screenshots.size() == mScreens.size();
         if (sameData) {
             for (int i = 0; i < ag.screenshots.size(); i++) {
-                if (!ag.screenshots.get(i).name.equals(_mScreens.get(i).name)) {
+                if (!ag.screenshots.get(i).name.equals(mScreens.get(i).name)) {
                     sameData = false;
                     break;
                 }
@@ -102,161 +68,18 @@ public class AppGroupActivity extends AppCompatActivity {
         }
         if (sameData)
             return;
-        _mScreens = (ArrayList<Screenshot>) ag.screenshots.clone();
-        _mSelectedScreens.clear();
-        checkAndChangeSelectionMode();
-        _logger.log("Displaying Scrrens of Appgroup", _appName, _mScreens.size());
-        _adapter = new AppGroupPageAdapter(getApplicationContext(), _mScreens, _mSelectedScreens);
-        _gridView.setAdapter(_adapter);
-        _gridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                Screenshot selected = _mScreens.get(i);
-                if (inSelectionMode()) {
-                    toggleSelection(selected);
-                    return;
-                }
-                _logger.log("The screen selected is", i, selected.name, "the appName: ", selected.appName);
-                Intent intent = new Intent(getBaseContext(), ScreenActivity.class);
-                intent.putExtra(ScreenActivity.INTENT_SCREEN_NAME, selected.name);
-                intent.putExtra(ScreenActivity.INTENT_SCREEN_POSITION, i);
-                intent.putExtra(ScreenActivity.INTENT_DISPLAY_TYPE, ScreenActivity.DISPLAY_APP_GROUP_ITEMS);
-                startActivityForResult(intent, SCREEN_ACTIVITY_INTENT_CODE);
-            }
-        });
-        _gridView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
-            @Override
-            public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-                if (inSelectionMode()) {
-                    return true;
-                }
-                toggleSelection(_mScreens.get(position));
-                return true;
-            }
-        });
+        mScreens = (ArrayList<Screenshot>) ag.screenshots.clone();
+        _logger.log("Displaying Scrrens of Appgroup", _appName, mScreens.size());
+        super.updateAdapter();
     }
 
-    private void exitSelectionMode() {
-        _mTextView.setText(_appName);
-        _mSelectActions.setVisibility(View.INVISIBLE);
-        _mToolbar.setNavigationIcon(getResources().getDrawable(R.drawable.back));
-    }
-
-    private void enterSelectionMode() {
-        String itemDisplayText = _mSelectedScreens.size() > 1 ? " items": " item";
-        String text;
-        if (_mSelectedScreens.size() == _mScreens.size()) {
-            text = "All(" + _mSelectedScreens.size() + ")";
-            _mSelectAll.setImageDrawable(getResources().getDrawable(R.drawable.ic_select_all_blue));
-        } else {
-            text = _mSelectedScreens.size() + "";
-            _mSelectAll.setImageDrawable(getResources().getDrawable(R.drawable.ic_select_all));
-        }
-        _mTextView.setText(text);
-        _mSelectActions.setVisibility(View.VISIBLE);
-        _mToolbar.setNavigationIcon(getResources().getDrawable(R.drawable.ic_close));
-    }
-
-    private void onSelectAll(View view) {
-        if (_mSelectedScreens.size() == _mScreens.size()) {
-           unMarkAll();
-        } else {
-            markAll();
-        }
-    }
-
-    private void onShare(View view) {
-        Intent intent = new Intent();
-        intent.setAction(Intent.ACTION_SEND_MULTIPLE);
-        intent.setType("image/*");
-
-        ArrayList<Uri> files = new ArrayList<Uri>();
-        for(Screenshot screen : _mSelectedScreens) {
-            _logger.log("Planning to share", screen.name);
-            Uri uri = FileProvider.getUriForFile(this, FILE_PROVIDER_AUTHORITY , screen.file);
-            files.add(uri);
-        }
-
-        intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, files);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        startActivity(intent);
-    }
-
-    private void onDelete(View view) {
-        ArrayList<Screenshot> toBeDeleted = new ArrayList<>();
-        for (Screenshot screen: _mSelectedScreens)
-            toBeDeleted.add(screen);
-        String Message = "Are you sure? You want to delete " + toBeDeleted.size();
-        Message +=  (toBeDeleted.size() > 1)? " images ": "image";
-        Message += "from your device permanently?";
-        _mAlertBuilder.setTitle("Delete")
-                .setMessage(Message)
-                .setPositiveButton(getResources().getString(R.string.delete_confirm), (dialog, which) -> {
-                    _logger.log("User confirmed to delete");
-                    ArrayList<Boolean> results = FileHelper.deleteScreenshotList(toBeDeleted);
-                    ArrayList<String> deletedScreens = new ArrayList<>();
-                    for (int i = 0; i < results.size(); i++) {
-                        Boolean status = results.get(i);
-                        Screenshot screen = toBeDeleted.get(i);
-                        if (status) {
-                            deletedScreens.add(screen.name);
-                        _logger.log("Successfully deleted the screenshot", screen.name, screen.appName);
-                        } else {
-                        _logger.log("Failed to delete the screenshot", screen.name, screen.appName);
-                        }
-                    }
-                    ScreenXApplication.screenFactory.removeScreenList(deletedScreens);
-                    unMarkAll();
-                    ScreenXApplication.screenFactory.refresh(this);
-                })
-                .setNegativeButton(getResources().getString(R.string.delete_cancel), null)
-                .show();
-    }
-
-    private void markAll() {
-        for (int i = 0; i < _mScreens.size(); i++) {
-            Screenshot screen = _mScreens.get(i);
-            if (!_mSelectedScreens.contains(screen)) {
-                _mSelectedScreens.add(screen);
-            }
-        }
-        checkAndChangeSelectionMode();
-        _adapter.notifyDataSetChanged();
-    }
-
-    private void unMarkAll() {
-        _mSelectedScreens.clear();
-        checkAndChangeSelectionMode();
-        _adapter.notifyDataSetChanged();
-    }
-
-    private void onNavigation(View view) {
-        if (inSelectionMode()) {
-            unMarkAll();
-        } else {
-            finish();
-        }
-    }
-
-    private void checkAndChangeSelectionMode() {
-        if (inSelectionMode())
-            enterSelectionMode();
-        else
-            exitSelectionMode();
-    }
-
-    private boolean inSelectionMode() {
-        return _mSelectedScreens.size() != 0;
-    }
-
-    private void toggleSelection(Screenshot screen) {
-        if (_mSelectedScreens.contains(screen)) {
-            _mSelectedScreens.remove(screen);
-        } else {
-            _mSelectedScreens.add(screen);
-        }
-        checkAndChangeSelectionMode();
-        _adapter.notifyDataSetChanged();
+    @Override
+    public Intent getTapIntent(Screenshot selected, int position) {
+        Intent intent = new Intent(getBaseContext(), ScreenActivity.class);
+        intent.putExtra(ScreenActivity.INTENT_SCREEN_NAME, selected.name);
+        intent.putExtra(ScreenActivity.INTENT_SCREEN_POSITION, position);
+        intent.putExtra(ScreenActivity.INTENT_DISPLAY_TYPE, ScreenActivity.DISPLAY_APP_GROUP_ITEMS);
+        return intent;
     }
 
     @Override

--- a/app/src/main/java/com/frankenstein/screenx/MultipleSelectActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/MultipleSelectActivity.java
@@ -1,0 +1,228 @@
+package com.frankenstein.screenx;
+
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.GridView;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import com.frankenstein.screenx.helper.FileHelper;
+import com.frankenstein.screenx.helper.Logger;
+import com.frankenstein.screenx.models.Screenshot;
+import com.frankenstein.screenx.ui.adapters.AppGroupPageAdapter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.FileProvider;
+
+import static com.frankenstein.screenx.Constants.FILE_PROVIDER_AUTHORITY;
+
+public class MultipleSelectActivity extends AppCompatActivity {
+    private ImageButton _mSelectAll;
+    private Toolbar _mDefaultToolbar;
+    private Toolbar _mSelectModeToolbar;
+    private ImageButton _mShare;
+    private ImageButton _mDelete;
+    private TextView _mSelectTitleView;
+    private AlertDialog.Builder _mAlertBuilder;
+    private Logger _mLogger = Logger.getInstance("MultipleSelectActivity");
+
+    protected ArrayList<Screenshot> mScreens = new ArrayList<>();
+    protected Set<Screenshot> mSelectedScreens = new HashSet<>();
+    protected BaseAdapter mAdapter;
+    protected GridView mGridView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        _mSelectAll = findViewById(R.id.select_all);
+        _mSelectAll.setOnClickListener(this::onSelectAll);
+        _mDefaultToolbar = findViewById(R.id.default_toolbar);
+        _mDefaultToolbar.setNavigationOnClickListener(this::defaultModeNavigation);
+        _mSelectModeToolbar = findViewById(R.id.select_toolbar);
+        _mSelectModeToolbar.setNavigationOnClickListener(this::selectModeNavigation);
+        _mShare = findViewById(R.id.share);
+        _mShare.setOnClickListener(this::onShare);
+        _mDelete = findViewById(R.id.delete);
+        _mDelete.setOnClickListener(this::onDelete);
+        _mSelectTitleView = findViewById(R.id.multipleselect_title);
+        _mAlertBuilder = new AlertDialog.Builder(this);
+        mGridView = findViewById(R.id.grid_view);
+    }
+
+    private void exitSelectionMode() {
+        _mSelectModeToolbar.setVisibility(View.INVISIBLE);
+        _mDefaultToolbar.setVisibility(View.VISIBLE);
+    }
+
+    private void enterSelectionMode() {
+        String text;
+        if (mSelectedScreens.size() == mScreens.size()) {
+            text = "All(" + mSelectedScreens.size() + ")";
+            _mSelectAll.setImageDrawable(getResources().getDrawable(R.drawable.ic_select_all_blue));
+        } else {
+            text = mSelectedScreens.size() + "";
+            _mSelectAll.setImageDrawable(getResources().getDrawable(R.drawable.ic_select_all));
+        }
+        _mSelectTitleView.setText(text);
+        _mSelectModeToolbar.setVisibility(View.VISIBLE);
+        _mDefaultToolbar.setVisibility(View.INVISIBLE);
+    }
+
+    private void onSelectAll(View view) {
+        if (mSelectedScreens.size() == mScreens.size()) {
+            unMarkAll();
+        } else {
+            markAll();
+        }
+    }
+
+    private void onShare(View view) {
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_SEND_MULTIPLE);
+        intent.setType("image/*");
+
+        ArrayList<Uri> files = new ArrayList<Uri>();
+        for(Screenshot screen : mSelectedScreens) {
+            _mLogger.log("Planning to share", screen.name);
+            Uri uri = FileProvider.getUriForFile(this, FILE_PROVIDER_AUTHORITY , screen.file);
+            files.add(uri);
+        }
+
+        intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, files);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(intent);
+    }
+
+    private void onDelete(View view) {
+        ArrayList<Screenshot> toBeDeleted = new ArrayList<>();
+        for (Screenshot screen: mSelectedScreens)
+            toBeDeleted.add(screen);
+        String Message = "Are you sure? You want to delete " + toBeDeleted.size();
+        Message +=  (toBeDeleted.size() > 1)? " images ": "image";
+        Message += "from your device permanently?";
+        _mAlertBuilder.setTitle("Delete")
+                .setMessage(Message)
+                .setPositiveButton(getResources().getString(R.string.delete_confirm), (dialog, which) -> {
+                    _mLogger.log("User confirmed to delete");
+                    ArrayList<Boolean> results = FileHelper.deleteScreenshotList(toBeDeleted);
+                    ArrayList<String> deletedScreens = new ArrayList<>();
+                    for (int i = 0; i < results.size(); i++) {
+                        Boolean status = results.get(i);
+                        Screenshot screen = toBeDeleted.get(i);
+                        if (status) {
+                            deletedScreens.add(screen.name);
+                            _mLogger.log("Successfully deleted the screenshot", screen.name, screen.appName);
+                        } else {
+                            _mLogger.log("Failed to delete the screenshot", screen.name, screen.appName);
+                        }
+                    }
+                    ScreenXApplication.screenFactory.removeScreenList(deletedScreens);
+                    unMarkAll();
+                    ScreenXApplication.screenFactory.refresh(this);
+                })
+                .setNegativeButton(getResources().getString(R.string.delete_cancel), null)
+                .show();
+    }
+
+    private void markAll() {
+        for (int i = 0; i < mScreens.size(); i++) {
+            Screenshot screen = mScreens.get(i);
+            if (!mSelectedScreens.contains(screen)) {
+                mSelectedScreens.add(screen);
+            }
+        }
+        checkAndChangeSelectionMode();
+        mAdapter.notifyDataSetChanged();
+    }
+
+    private void unMarkAll() {
+        mSelectedScreens.clear();
+        checkAndChangeSelectionMode();
+        mAdapter.notifyDataSetChanged();
+    }
+
+    private void selectModeNavigation(View view) {
+        unMarkAll();
+    }
+
+    private void defaultModeNavigation(View view) {
+        finish();
+    }
+
+    protected void checkAndChangeSelectionMode() {
+        if (inSelectionMode())
+            enterSelectionMode();
+        else
+            exitSelectionMode();
+    }
+
+    protected boolean inSelectionMode() {
+        return mSelectedScreens.size() != 0;
+    }
+
+    protected void toggleSelection(Screenshot screen) {
+        if (mSelectedScreens.contains(screen)) {
+            mSelectedScreens.remove(screen);
+        } else {
+            mSelectedScreens.add(screen);
+        }
+        checkAndChangeSelectionMode();
+        mAdapter.notifyDataSetChanged();
+    }
+
+    protected void updateAdapter() {
+        mSelectedScreens.clear();
+        checkAndChangeSelectionMode();
+        mAdapter = new AppGroupPageAdapter(getApplicationContext(), mScreens, mSelectedScreens);
+        mGridView.setAdapter(mAdapter);
+        mGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                Screenshot selected = mScreens.get(i);
+
+                if (inSelectionMode()) {
+                   toggleSelection(selected);
+                   return;
+                }
+
+                _mLogger.log("The screen selected is", i, selected.name, "the appName: ", selected.appName);
+                Intent intent = getTapIntent(selected, i);
+                if (intent != null)
+                    startActivity(intent);
+            }
+        });
+        mGridView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+                if (inSelectionMode()) {
+                    return true;
+                }
+                toggleSelection(mScreens.get(position));
+                return true;
+            }
+        });
+    }
+
+    public Intent getTapIntent(Screenshot selected, int position) {
+        return null;
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (inSelectionMode()) {
+            unMarkAll();
+            return;
+        }
+        super.onBackPressed();
+    }
+}

--- a/app/src/main/java/com/frankenstein/screenx/ui/adapters/AppGroupPageAdapter.java
+++ b/app/src/main/java/com/frankenstein/screenx/ui/adapters/AppGroupPageAdapter.java
@@ -21,13 +21,12 @@ import androidx.appcompat.widget.AppCompatCheckBox;
 public class AppGroupPageAdapter extends BaseAdapter {
     private Context _context;
     private ArrayList<Screenshot> _screens;
-    private Logger _logger;
+    private Logger _logger = Logger.getInstance("AppGroupPageAdapter");
     private Set<Screenshot> _mSelectedScreens;
 
     public AppGroupPageAdapter(Context context, ArrayList<Screenshot> arrayList, Set<Screenshot> selectedScreens) {
         this._context = context;
         this._screens = arrayList;
-        this._logger = Logger.getInstance("AppGroupPageAdapter");
         this._mSelectedScreens = selectedScreens;
     }
     @Override

--- a/app/src/main/res/layout/appgrouppage.xml
+++ b/app/src/main/res/layout/appgrouppage.xml
@@ -3,67 +3,21 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
+    <FrameLayout
+        android:id="@+id/toolbar_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/white"
-        android:elevation="4dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="@drawable/back">
-
-        <TextView
-            android:id="@+id/page_title"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginEnd="60dp"
-            android:background="@android:color/transparent"
-            android:selectAllOnFocus="true"
-            android:textSize="24dp"
-            android:text="App Group Page"/>
-        <LinearLayout
-            android:id="@+id/select_actions"
-            android:layout_width="150dp"
-            android:layout_height="40dp"
-            android:orientation="horizontal"
-            android:layout_gravity="center_vertical|end"
-            android:layout_marginEnd="12dp">
-<!--            <ImageButton-->
-<!--                android:id="@+id/clear"-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:src="@drawable/edit_close"-->
-<!--                android:visibility="invisible"-->
-<!--                android:background="?android:attr/selectableItemBackgroundBorderless"/>-->
-            <ImageButton
-                android:id="@+id/share"
-                android:layout_width="40dp"
-                android:layout_height="match_parent"
-                android:src="@drawable/ic_share_black"
-                android:layout_marginHorizontal="5dp"
-                android:background="?android:attr/selectableItemBackgroundBorderless"/>
-            <ImageButton
-                android:id="@+id/delete"
-                android:layout_width="40dp"
-                android:layout_height="match_parent"
-                android:src="@drawable/ic_delete_black"
-                android:layout_marginHorizontal="5dp"
-
-                android:background="?android:attr/selectableItemBackgroundBorderless"/>
-            <ImageButton
-                android:id="@+id/select_all"
-                android:layout_width="40dp"
-                android:layout_height="match_parent"
-                android:src="@drawable/ic_select_all"
-                android:layout_marginHorizontal="5dp"
-                android:background="?android:attr/selectableItemBackgroundBorderless"/>
-        </LinearLayout>
-    </androidx.appcompat.widget.Toolbar>
+        app:layout_constraintTop_toTopOf="parent">
+        <include
+            layout="@layout/multipleselect_toolbar"/>
+        <include
+            layout="@layout/appgrouppage_default_toolbar"/>
+    </FrameLayout>
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/pull_to_refresh"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/toolbar">
+        app:layout_constraintTop_toBottomOf="@id/toolbar_container">
         <GridView xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/grid_view"
             android:numColumns="3"

--- a/app/src/main/res/layout/appgrouppage_default_toolbar.xml
+++ b/app/src/main/res/layout/appgrouppage_default_toolbar.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/default_toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/white"
+    android:elevation="4dp"
+    app:navigationIcon="@drawable/back"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/appgrouppage_title"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="60dp"
+        android:background="@android:color/transparent"
+        android:selectAllOnFocus="true"
+        android:textSize="24dp"
+        android:text="App Group Page"/>
+<!--    <ImageButton-->
+<!--        android:id="@+id/clear"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent"-->
+<!--        android:src="@drawable/ic_close"-->
+<!--        android:visibility="invisible"-->
+<!--        android:background="?android:attr/selectableItemBackgroundBorderless"/>-->
+
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/multipleselect_toolbar.xml
+++ b/app/src/main/res/layout/multipleselect_toolbar.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/select_toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/white"
+    android:elevation="4dp"
+    app:navigationIcon="@drawable/ic_close"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/multipleselect_title"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="60dp"
+        android:background="@android:color/transparent"
+        android:selectAllOnFocus="true"
+        android:textSize="24dp"/>
+    <LinearLayout
+        android:id="@+id/select_actions"
+        android:layout_width="150dp"
+        android:layout_height="40dp"
+        android:orientation="horizontal"
+        android:layout_gravity="center_vertical|end"
+        android:layout_marginEnd="12dp">
+        <ImageButton
+            android:id="@+id/share"
+            android:layout_width="40dp"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_share_black"
+            android:layout_marginHorizontal="5dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"/>
+        <ImageButton
+            android:id="@+id/delete"
+            android:layout_width="40dp"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_delete_black"
+            android:layout_marginHorizontal="5dp"
+
+            android:background="?android:attr/selectableItemBackgroundBorderless"/>
+        <ImageButton
+            android:id="@+id/select_all"
+            android:layout_width="40dp"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_select_all"
+            android:layout_marginHorizontal="5dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"/>
+    </LinearLayout>
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/searchpage.xml
+++ b/app/src/main/res/layout/searchpage.xml
@@ -3,37 +3,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
+    <FrameLayout
+        android:id="@+id/toolbar_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/white"
-        android:elevation="4dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="@drawable/back">
-
-        <androidx.appcompat.widget.AppCompatAutoCompleteTextView
-            android:id="@+id/automcomplete_search"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginEnd="60dp"
-            android:background="@android:color/transparent"
-            android:imeOptions="actionDone"
-            android:selectAllOnFocus="true"
-            android:singleLine="true" />
-
-        <ImageButton
-            android:id="@+id/clear"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_gravity="center_vertical|end"
-            android:layout_marginEnd="12dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_close"
-            android:visibility="invisible" />
-    </androidx.appcompat.widget.Toolbar>
-
+        app:layout_constraintTop_toTopOf="parent">
+        <include
+            layout="@layout/multipleselect_toolbar"/>
+        <include
+            layout="@layout/searchpage_default_toolbar"/>
+    </FrameLayout>
     <GridView xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/grid_view"
         android:numColumns="3"
@@ -43,5 +22,5 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/lightWhite"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar_container" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/searchpage_default_toolbar.xml
+++ b/app/src/main/res/layout/searchpage_default_toolbar.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/default_toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/white"
+    android:elevation="4dp"
+    app:navigationIcon="@drawable/back"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.AppCompatAutoCompleteTextView
+        android:id="@+id/automcomplete_search"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="60dp"
+        android:background="@android:color/transparent"
+        android:imeOptions="actionDone"
+        android:selectAllOnFocus="true"
+        android:singleLine="true" />
+    <ImageButton
+        android:id="@+id/clear"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center_vertical|end"
+        android:layout_marginEnd="12dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_close"
+        android:visibility="invisible" />
+</androidx.appcompat.widget.Toolbar>


### PR DESCRIPTION
1. As search activity and app group page activity share lot of common
   code, made them a common parent class `MultipleSelectActivity` which
   handles all of the multi select, share and delete functionalities
2. In selection Mode on both appgroup page and search pages, clicking back
   button will unselect all screenshots and exit selection mode

Signed-off-by: pavan142 <pa1tirumani@gmail.com>