### PR TITLE
Fixed crash on devices that do not support usage access intent.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,9 @@
     <string name="miscellaneous_app_name">Miscellaneous</string>
     <string name="service_description"> This service allows you to take screenshots with floatcing touch bar or through notification panel</string>
 
+    <!-- Usage Settings Dialog for devices that do not support usage setting intent-->
+    <string name = "usage_settings_confirm">Go To Settings</string>
+
     <!-- Delete Dialog-->
     <string name="delete_confirm">Confirm</string>
     <string name="delete_cancel">Cancel</string>


### PR DESCRIPTION
1. On some model variants of Samsung and LG, Usage Access Intent is removed,
   so when the user presses to `Go to Usage Settings` on Permissions Screen,
   this is leading to app crash.
2. This CL fixes this issue by checking if usage settings intent is supported, if
   not, an alert dialog is displayed instead guiding user manually to the usage access from
   settings.

Closes #23

Signed-off-by: pavan142 <pa1tirumani@gmail.com>