### PR TITLE
Added Support for grouping System Screenshots on Samsung Models

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/Constants.java
+++ b/app/src/main/java/com/frankenstein/screenx/Constants.java
@@ -1,12 +1,16 @@
 package com.frankenstein.screenx;
 
+import java.util.regex.Pattern;
+
 public class Constants {
-    public static final String SCREENSHOT_SUFFIX_PATTERN ="_[a-z0-9.]*.jpg$";
-    public static final String SCREENSHOT_PREFIX_PATTERN ="^Screenshot_[0-9-]*_";;
+    public static final Pattern SCREENSHOT_SUFFIX_PATTERN = Pattern.compile("_[a-z0-9.]*.jpg$");
+    public static final Pattern SCREENSHOT_PREFIX_PATTERN = Pattern.compile("^Screenshot_[0-9-]*_");
+    public static final Pattern HEURISTIC_APPNAME_PATTERN = Pattern.compile("[a-zA-Z0-9]*$");
     public static final String SCREENSHOT_DIR = "ScreenX";
     public static final int PROGRESSBAR_TRANSITION = 700;
     public static final int TOOLBAR_TRANSITION = 100;
     public static final String DB_NAME="screenshots-db";
     public static final String DB_THREAD_NAME ="db-thread";
     public static final String FILE_PROVIDER_AUTHORITY="com.frankenstein.screenx.fileprovider";
+    public static final String SCREENSHOT_DEFAULT_APPGROUP = "Miscellaneous";
 }

--- a/app/src/main/java/com/frankenstein/screenx/MainActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/MainActivity.java
@@ -17,7 +17,6 @@ import android.widget.GridView;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
-import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.MutableLiveData;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -25,7 +24,6 @@ import java.util.ArrayList;
 
 import android.content.Intent;
 
-import com.frankenstein.screenx.helper.FileHelper;
 import com.frankenstein.screenx.helper.Logger;
 import com.frankenstein.screenx.helper.PermissionHelper;
 import com.frankenstein.screenx.models.AppGroup;
@@ -58,8 +56,6 @@ public class MainActivity extends AppCompatActivity {
     private View _mHomePageContentLayout;
     private View _mHomePageContentEmpty;
     private View _mHomePageDisplayContent;
-
-    private Toolbar _mToolbar;
 
     private MutableLiveData<HomePageState> _mState = new MutableLiveData<>();
     private HomePageState _mPrevState = HomePageState.REQUEST_PERMISSIONS;

--- a/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
+++ b/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
@@ -14,7 +14,7 @@ import com.frankenstein.screenx.multithreading.GetScreensAsyncTask;
 
 import androidx.lifecycle.MutableLiveData;
 
-import static com.frankenstein.screenx.helper.AppHelper.getScreenFromFile;
+import static com.frankenstein.screenx.helper.AppHelper.GetScreenFromFile;
 
 public class ScreenFactory {
     private static ScreenFactory _instance;
@@ -130,7 +130,7 @@ public class ScreenFactory {
     public void onScreenAdded(Context context,String filepath) {
         _logger.log("ScreenFactory: onScreenAdded", filepath);
         File file = new File(filepath);
-        Screenshot screen = getScreenFromFile(context, file);
+        Screenshot screen = GetScreenFromFile(context, file);
         addScreen(screen);
 
         ArrayList<Screenshot> newScreenshots = screenshots.getValue();

--- a/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
+++ b/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
@@ -10,7 +10,7 @@ import com.frankenstein.screenx.models.Screenshot;
 import java.io.File;
 import java.util.ArrayList;
 
-import static com.frankenstein.screenx.helper.AppHelper.getScreenFromFile;
+import static com.frankenstein.screenx.helper.AppHelper.GetScreenFromFile;
 import static com.frankenstein.screenx.helper.FileHelper.getAllScreenshotFiles;
 
 public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Screenshot>> {
@@ -29,10 +29,9 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
         final Context context = (Context) objects[0];
         ArrayList<Screenshot> screens = new ArrayList<>();
         try {
-
             ArrayList<File> files = getAllScreenshotFiles();
             for (File file : files) {
-                Screenshot screen = getScreenFromFile(context, file);
+                Screenshot screen = GetScreenFromFile(context, file);
                 screens.add(screen);
             }
             Long end = System.currentTimeMillis();


### PR DESCRIPTION
 1. Samsung Models store the screenshots with the naming convention `..._<appName>.jpg` which will be handled with this CL
    
 2. This CL also handles an uninstalled application's screenshots, by heuristically determing the app label. That is from packageId `com.foocompany.sampleapp` -> get the last part(`sampleapp`) and Capitalize the first character (`Sampleapp`)
    
    Closes #28
 Signed-off-by: pavan142 <pa1tirumani@gmail.com>