### PR TITLE
Stop recognizing hash name in the screenshot name as the app name.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.frankenstein.screenx"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 6
-        versionName "1.4"
+        versionCode 7
+        versionName "1.4.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
@@ -40,7 +40,9 @@ public class AppHelper {
             return Constants.SCREENSHOT_DEFAULT_APPGROUP;
         }
         String matched = matcher.group();
-        if (matched.length() < 2)
+        // The maximum length is to stop it recognizing from hashed screenshots
+        // like on Realme devices: Example: Screenshot_<time>_ae8e34gq5wgwgw43t314teggqwffae12.jpg
+        if (matched.length() < 2 || matched.length() > 24)
             return Constants.SCREENSHOT_DEFAULT_APPGROUP;
 
         String appName = matched.substring(0, 1).toUpperCase() + matched.substring(1);


### PR DESCRIPTION
1. The recently added support for heuristic app naming helps detect app names for
   uninstalled apps by rule based analysis of packageId
2. But it is erroneoulsy detecting hash named screenshots too and creating app groups
   of one for them. So fixed this by having a maximum character limit for heuristically
   determined app name. (The limit is set as 24 to be on the safe side). Most hashes used
   are 32 character length.

   Example: Screenshot_<time>_ae8e34gq5wgwgw43t314teggqwffae12.jpg
3. Version Increase to 7 (Version Name 1.4.1)

Signed-off-by: pavan142 <pa1tirumani@gmail.com>