### PR TITLE
Added support for sorting old system screenshots

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/Constants.java
+++ b/app/src/main/java/com/frankenstein/screenx/Constants.java
@@ -1,5 +1,6 @@
 package com.frankenstein.screenx;
 
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
 
 public class Constants {
@@ -13,4 +14,6 @@ public class Constants {
     public static final String DB_THREAD_NAME ="db-thread";
     public static final String FILE_PROVIDER_AUTHORITY="com.frankenstein.screenx.fileprovider";
     public static final String SCREENSHOT_DEFAULT_APPGROUP = "Miscellaneous";
+    public static final DateTimeFormatter SCREEN_DATE_FORMAT  = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss-SSS");
+
 }

--- a/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
+++ b/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import android.content.Context;
 
 import com.frankenstein.screenx.helper.Logger;
+import com.frankenstein.screenx.helper.SortHelper;
 import com.frankenstein.screenx.models.AppGroup;
 import com.frankenstein.screenx.models.Screenshot;
 import com.frankenstein.screenx.multithreading.GetScreensAsyncTask;
@@ -15,6 +16,7 @@ import com.frankenstein.screenx.multithreading.GetScreensAsyncTask;
 import androidx.lifecycle.MutableLiveData;
 
 import static com.frankenstein.screenx.helper.AppHelper.GetScreenFromFile;
+import static com.frankenstein.screenx.helper.SortHelper.DESC_TIME;
 
 public class ScreenFactory {
     private static ScreenFactory _instance;
@@ -84,12 +86,7 @@ public class ScreenFactory {
                 newAlphaSorted.add(i);
             }
 
-
-            Collections.sort(newDateSorted, (AppGroup appGroup, AppGroup t1) -> {
-                long result = (t1.lastModified - appGroup.lastModified);
-                int output = (result >=0 ) ? 1: -1;
-                return output;
-            });
+            DESC_TIME(newDateSorted);
 
             Collections.sort(newAlphaSorted, (AppGroup appGroup, AppGroup t1) -> {
                 return appGroup.appName.compareTo(t1.appName);

--- a/app/src/main/java/com/frankenstein/screenx/capture/ScreenCaptureManager.kt
+++ b/app/src/main/java/com/frankenstein/screenx/capture/ScreenCaptureManager.kt
@@ -21,17 +21,16 @@ import android.os.Looper
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
+import com.frankenstein.screenx.Constants.SCREEN_DATE_FORMAT
 
 import com.frankenstein.screenx.helper.Logger
 import com.frankenstein.screenx.R
-import com.frankenstein.screenx.helper.UsageStatsHelper.Companion.getRecentAppViaUsage
-import com.frankenstein.screenx.helper.UsageStatsHelper.Companion.getRecentAppViaEvents
+import com.frankenstein.screenx.helper.UsageStatsHelper.Companion.lastForegroundApp
 import com.frankenstein.screenx.helper.FileHelper.CUSTOM_SCREENSHOT_DIR
 import com.frankenstein.screenx.helper.FileHelper.createIfNot
 
 import java.io.FileOutputStream
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 
 class ScreenCaptureManager(context: Context, private val screenCapturePermissionIntent: Intent, private val screenCaptureListener: ScreenCaptureListener) {
@@ -53,7 +52,6 @@ class ScreenCaptureManager(context: Context, private val screenCapturePermission
     private val activityManager: ActivityManager;
     private val usm: UsageStatsManager;
     private val defaultPackageId: String;
-    private val screenDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss-SSS")
 
     init {
         val screenshotDirectory = CUSTOM_SCREENSHOT_DIR;
@@ -115,11 +113,10 @@ class ScreenCaptureManager(context: Context, private val screenCapturePermission
             imageReader?.setOnImageAvailableListener(null, null)
 
             val date: LocalDateTime = LocalDateTime.now();
-            val dateString: String = date.format(screenDateFormat);
-            val appViaUsage = getRecentAppViaUsage(usm);
-            val appViaEvents = getRecentAppViaEvents(usm);
-            _logger.log("recentAppViaUsage", appViaUsage, "recentAppViaEvent", appViaEvents);
-            val filePath: String = screenshotPath + "/Screenshot_" + dateString +"_" + appViaEvents +".jpg"
+            val dateString: String = date.format(SCREEN_DATE_FORMAT);
+            val packageId = lastForegroundApp(usm);
+            _logger.log("lastForegroundApp", packageId);
+            val filePath: String = screenshotPath + "/Screenshot_" + dateString +"_" + packageId +".jpg"
 //            var bitmap: Bitmap? = null
             var croppedBitmap: Bitmap? = null
 

--- a/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
@@ -1,18 +1,27 @@
 package com.frankenstein.screenx.helper;
 
+import android.app.usage.UsageStatsManager;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 
 import com.frankenstein.screenx.Constants;
+import com.frankenstein.screenx.interfaces.TimeSortable;
 import com.frankenstein.screenx.models.Screenshot;
+import com.frankenstein.screenx.helper.UsageStatsHelper.Companion.*;
 
 import java.io.File;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import static com.frankenstein.screenx.Constants.SCREENSHOT_DEFAULT_APPGROUP;
+import static com.frankenstein.screenx.helper.SortHelper.ASC_TIME;
+import static com.frankenstein.screenx.helper.TimeHelper.getReadableTime;
 
 public class AppHelper {
     private static final Map<String, String> _packageToAppName = new HashMap<>();
@@ -20,15 +29,15 @@ public class AppHelper {
 
     private static String getAppName(PackageManager _pm, String packageId) {
         if (!_packageToAppName.containsKey(packageId)) {
-            _mLogger.d("Did not find in packageToAppName", packageId);
             ApplicationInfo ai;
             try {
                 ai = _pm.getApplicationInfo( packageId, 0);
             } catch (final PackageManager.NameNotFoundException e) {
-                _mLogger.d("PackageId not found", packageId);
                 ai = null;
             }
             final String appName = (String) (ai != null ? _pm.getApplicationLabel(ai) : heuristicAppName(packageId));
+            if (appName == null)
+                return null;
             _packageToAppName.put(packageId, appName);
         }
         return _packageToAppName.get(packageId);
@@ -37,26 +46,59 @@ public class AppHelper {
     private static String heuristicAppName(String packageId) {
         Matcher matcher = Constants.HEURISTIC_APPNAME_PATTERN.matcher(packageId);
         if (!matcher.find()) {
-            return Constants.SCREENSHOT_DEFAULT_APPGROUP;
+            return null;
         }
         String matched = matcher.group();
         // The maximum length is to stop it recognizing from hashed screenshots
         // like on Realme devices: Example: Screenshot_<time>_ae8e34gq5wgwgw43t314teggqwffae12.jpg
         if (matched.length() < 2 || matched.length() > 24)
-            return Constants.SCREENSHOT_DEFAULT_APPGROUP;
+            return null;
 
         String appName = matched.substring(0, 1).toUpperCase() + matched.substring(1);
         _mLogger.log("Returning Heuristic App Name", appName);
         return appName;
     }
 
+    private static void assignAppNamesViaUsageEvents(Context context, ArrayList<Screenshot> screens) {
+        _mLogger.log("Starting assignAppNamesViaUsageEvents");
+        UsageStatsManager usm = (UsageStatsManager) context.getSystemService(Context.USAGE_STATS_SERVICE);
+        PackageManager pm = context.getPackageManager();
+        ArrayList<ForeGroundAppEvent> fgEvents = UsageStatsHelper.getArchivedFgEventTimeline(usm);
+        ArrayList<CompoundEvent> allEvents = new ArrayList<>();
+
+        for (Screenshot screen: screens)
+            allEvents.add(new CompoundEvent(screen));
+        for (ForeGroundAppEvent event: fgEvents)
+            allEvents.add(new CompoundEvent(event));
+
+
+        // (TODO) ASC_TIME is misbehaving for some reason
+//        ASC_TIME(allEvents);
+        Collections.sort(allEvents, (compoundEvent, t1) -> {
+            long result = t1.lastModified - compoundEvent.lastModified;
+            int output = (result <= 0 ) ? 1: -1;
+            return output;
+        });
+        ForeGroundAppEvent lastFgEvent = null;
+        for (int i = 0; i < allEvents.size(); i++) {
+            CompoundEvent event = allEvents.get(i);
+            if (!event.isScreen) {
+                lastFgEvent = event.fgEvent;
+            } else if (i > 0 && lastFgEvent != null) {
+                String lastSeenAppName = getAppName(pm, lastFgEvent.getMPackageName());
+                event.screen.appName = lastSeenAppName == null ? SCREENSHOT_DEFAULT_APPGROUP: lastSeenAppName;
+            } else {
+                event.screen.appName = SCREENSHOT_DEFAULT_APPGROUP;
+            }
+        }
+    }
+
     private static String getSourceApp(Context context, String filename) {
-        final PackageManager _pm = context.getPackageManager();
+        PackageManager pm = context.getPackageManager();
         Matcher matcher = Constants.SCREENSHOT_PREFIX_PATTERN.matcher(filename);
 
         if (!matcher.find()) {
-            _mLogger.d("No Match Found", filename);
-            return Constants.SCREENSHOT_DEFAULT_APPGROUP;
+            return null;
         }
 
         String matched = matcher.group();
@@ -65,13 +107,29 @@ public class AppHelper {
         int endIndex = filename.length() - 4;
         int startIndex = matched.length();
         if (endIndex <= startIndex) {
-            _mLogger.d("No Match Found", filename);
-            return Constants.SCREENSHOT_DEFAULT_APPGROUP;
+            return null;
         }
         String packageId = filename.substring(startIndex, endIndex);
-        String appName = getAppName(_pm, packageId);
-        appName = (appName == "") ? Constants.SCREENSHOT_DEFAULT_APPGROUP : appName;
+        String appName = getAppName(pm, packageId);
+        appName = (appName.compareTo("") == 0) ? null : appName;
         return appName;
+    }
+
+    public static ArrayList<Screenshot> GetMultipleScreens(Context context, ArrayList<File> files) {
+        ArrayList <Screenshot> screens = new ArrayList<>();
+        ArrayList <Screenshot> nullAppScreens = new ArrayList<>();
+        for (File file: files) {
+            String fileName = file.getName();
+            String appName = getSourceApp(context, fileName);
+            Screenshot screen = new Screenshot(fileName, file.getAbsolutePath(), appName);
+            screens.add(screen);
+            if (appName == null) {
+                nullAppScreens.add(screen);
+            }
+        }
+        _mLogger.log("NullAppScreens Length", nullAppScreens.size());
+        assignAppNamesViaUsageEvents(context, nullAppScreens);
+        return screens;
     }
 
 
@@ -80,5 +138,24 @@ public class AppHelper {
         String appName = getSourceApp(context, fileName);
         Screenshot screen = new Screenshot(fileName, file.getAbsolutePath(), appName);
         return screen;
+    }
+
+    static class CompoundEvent extends TimeSortable {
+        public Boolean isScreen = false;
+        public long lastModified;
+        public Screenshot screen;
+        public ForeGroundAppEvent fgEvent;
+
+        public CompoundEvent(ForeGroundAppEvent _fgEvent) {
+            isScreen = false;
+            fgEvent = _fgEvent;
+            lastModified = fgEvent.getMTimestamp();
+        }
+
+        public CompoundEvent(Screenshot _screen) {
+            isScreen = true;
+            screen = _screen;
+            lastModified = screen.lastModified;
+        }
     }
 }

--- a/app/src/main/java/com/frankenstein/screenx/helper/SortHelper.kt
+++ b/app/src/main/java/com/frankenstein/screenx/helper/SortHelper.kt
@@ -1,0 +1,36 @@
+package com.frankenstein.screenx.helper
+
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import com.frankenstein.screenx.ScreenFactory
+import com.frankenstein.screenx.ScreenXApplication
+import com.frankenstein.screenx.interfaces.TimeSortable
+import com.frankenstein.screenx.models.Screenshot
+import java.util.*
+import kotlin.collections.ArrayList
+
+public class SortHelper {
+    companion object {
+
+        @JvmStatic
+        fun<T: TimeSortable> DESC_TIME(input: ArrayList<T>) {
+            input.sortByDescending { it -> it.lastModified }
+        }
+
+        @JvmStatic
+        fun<T: TimeSortable> ASC_TIME(input: ArrayList<T>) {
+            input.sortBy{it -> it.lastModified}
+        }
+
+        @JvmStatic
+        fun DESC_SCREENS_BY_TIME(input: ArrayList<String>) {
+            input.sortByDescending{it -> ScreenXApplication.screenFactory.findScreenByName(it).lastModified}
+        }
+
+        @JvmStatic
+        fun ASC_SCREENS_BY_TIME(input: ArrayList<String>) {
+            input.sortBy{it -> ScreenXApplication.screenFactory.findScreenByName(it).lastModified}
+        }
+
+    }
+}

--- a/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
@@ -21,8 +21,6 @@ import com.google.mlkit.vision.text.TextRecognizer;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +32,8 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import static com.frankenstein.screenx.Constants.DB_THREAD_NAME;
+import static com.frankenstein.screenx.helper.SortHelper.DESC_SCREENS_BY_TIME;
+import static com.frankenstein.screenx.helper.SortHelper.DESC_TIME;
 
 public class TextHelper {
     private static TextHelper _mInstance;
@@ -115,14 +115,7 @@ public class TextHelper {
                 unParsedScreens.add(screen);
             }
         }
-        Collections.sort(unParsedScreens, new Comparator<Screenshot>() {
-            @Override
-            public int compare(Screenshot s1, Screenshot s2) {
-                long result = (s2.lastModified - s1.lastModified);
-                int output = (result >=0 ) ? 1: -1;
-                return output;
-            }
-        });
+        DESC_TIME(unParsedScreens);
         _mLogger.log("UnParsedScreenshots length", unParsedScreens.size());
         return unParsedScreens;
     }
@@ -142,16 +135,7 @@ public class TextHelper {
                 if (ScreenXApplication.screenFactory.findScreenByName(item.filename) != null)
                     screens.add(item.filename);
             }
-            Collections.sort(screens, new Comparator<String>() {
-                @Override
-                public int compare(String o1, String o2) {
-                    Screenshot s1 = ScreenXApplication.screenFactory.findScreenByName(o1);
-                    Screenshot s2 = ScreenXApplication.screenFactory.findScreenByName(o2);
-                    long result = (s2.lastModified - s1.lastModified);
-                    int output = (result >=0 ) ? 1: -1;
-                    return output;
-                }
-            });
+            DESC_SCREENS_BY_TIME(screens);
             livescreens.postValue(screens);
         });
         return livescreens;

--- a/app/src/main/java/com/frankenstein/screenx/helper/TimeHelper.kt
+++ b/app/src/main/java/com/frankenstein/screenx/helper/TimeHelper.kt
@@ -4,6 +4,7 @@ import java.util.*
 
 class TimeHelper {
     companion object {
+        @JvmStatic
         fun getReadableTime(time: Long): String {
             val date = Date(time);
             return date.toString();

--- a/app/src/main/java/com/frankenstein/screenx/helper/UsageStatsHelper.kt
+++ b/app/src/main/java/com/frankenstein/screenx/helper/UsageStatsHelper.kt
@@ -27,31 +27,52 @@ class UsageStatsHelper {
             return packageName;
         }
 
-        private class ForeGroundAppEvent(timestamp: Long, packageName: String) {
+        public class ForeGroundAppEvent(timestamp: Long, packageName: String) {
             val mTimestamp: Long = timestamp
             val mPackageName: String = packageName
         }
 
-        fun getRecentAppViaEvents(usm: UsageStatsManager): String {
+        fun lastForegroundApp(usm: UsageStatsManager): String {
             var calendar = Calendar.getInstance()
             val endTime = calendar.timeInMillis
             calendar.add(Calendar.HOUR, -1)
             val startTime = calendar.timeInMillis
-
             var packageName = "";
+            val appList: ArrayList<ForeGroundAppEvent> = filterFgEvents(usm, startTime, endTime);
+            appList.sortByDescending { i -> i.mTimestamp }
+            if (appList.size > 0)
+                packageName = appList.get(0).mPackageName
+            return packageName
+        }
+
+        @JvmStatic
+        fun getArchivedFgEventTimeline(usm: UsageStatsManager): ArrayList<ForeGroundAppEvent> {
+            var calendar = Calendar.getInstance()
+            val endTime = calendar.timeInMillis
+            calendar.add(Calendar.MONTH, -1)
+            val startTime = calendar.timeInMillis
+            return filterFgEvents(usm, startTime, endTime);
+        }
+
+        @JvmStatic
+        fun getLiveFgEventTimeline(usm: UsageStatsManager): ArrayList<ForeGroundAppEvent> {
+            var calendar = Calendar.getInstance()
+            val endTime = calendar.timeInMillis
+            calendar.add(Calendar.HOUR, -1)
+            val startTime = calendar.timeInMillis
+            return filterFgEvents(usm, startTime, endTime);
+        }
+
+        fun filterFgEvents(usm: UsageStatsManager, startTime: Long, endTime: Long): ArrayList<ForeGroundAppEvent> {
             val usageEvents = usm.queryEvents(startTime, endTime);
             var ev: UsageEvents.Event = UsageEvents.Event();
             val appList: ArrayList<ForeGroundAppEvent> = ArrayList()
             while (usageEvents.getNextEvent(ev)) {
                 if (ev.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
-                    packageName = ev.packageName;
                     appList.add(ForeGroundAppEvent(ev.timeStamp, ev.packageName))
                 }
             }
-            appList.sortByDescending { i -> i.mTimestamp }
-            if (appList.size > 0)
-                packageName = appList.get(0).mPackageName
-            return packageName
+            return appList;
         }
     }
 }

--- a/app/src/main/java/com/frankenstein/screenx/interfaces/TimeSortable.java
+++ b/app/src/main/java/com/frankenstein/screenx/interfaces/TimeSortable.java
@@ -1,0 +1,6 @@
+package com.frankenstein.screenx.interfaces;
+
+public abstract class TimeSortable {
+    public long lastModified;
+}
+

--- a/app/src/main/java/com/frankenstein/screenx/models/AppGroup.java
+++ b/app/src/main/java/com/frankenstein/screenx/models/AppGroup.java
@@ -1,13 +1,16 @@
 package com.frankenstein.screenx.models;
 
+import com.frankenstein.screenx.interfaces.TimeSortable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 
-public class AppGroup {
+import static com.frankenstein.screenx.helper.SortHelper.DESC_TIME;
+
+public class AppGroup extends TimeSortable {
     public String appName;
     public ArrayList<Screenshot> screenshots;
     public Screenshot mascot;
-    public long lastModified;
 
     public AppGroup(String _appName) {
         this.appName = _appName;
@@ -23,10 +26,6 @@ public class AppGroup {
     }
 
     public void sort() {
-        Collections.sort(screenshots, (Screenshot screenshot, Screenshot t1) -> {
-                long result = (t1.lastModified - screenshot.lastModified);
-                int output = (result >= 0 ) ? 1: -1;
-                return output;
-            });
+        DESC_TIME(screenshots);
     }
 }

--- a/app/src/main/java/com/frankenstein/screenx/models/Screenshot.java
+++ b/app/src/main/java/com/frankenstein/screenx/models/Screenshot.java
@@ -1,13 +1,14 @@
 package com.frankenstein.screenx.models;
 
+import com.frankenstein.screenx.interfaces.TimeSortable;
+
 import java.io.File;
 
-public class Screenshot {
+public class Screenshot extends TimeSortable {
     public String name;
     public File file;
     public String appName;
     public String filePath;
-    public long lastModified;
 
     public Screenshot(String name, String filePath, String appName) {
         this.name = name;

--- a/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
+++ b/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
@@ -10,7 +10,7 @@ import com.frankenstein.screenx.models.Screenshot;
 import java.io.File;
 import java.util.ArrayList;
 
-import static com.frankenstein.screenx.helper.AppHelper.GetScreenFromFile;
+import static com.frankenstein.screenx.helper.AppHelper.GetMultipleScreens;
 import static com.frankenstein.screenx.helper.FileHelper.getAllScreenshotFiles;
 
 public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Screenshot>> {
@@ -30,11 +30,9 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
         ArrayList<Screenshot> screens = new ArrayList<>();
         try {
             ArrayList<File> files = getAllScreenshotFiles();
-            for (File file : files) {
-                Screenshot screen = GetScreenFromFile(context, file);
-                screens.add(screen);
-            }
+            screens = GetMultipleScreens(context, files);
             Long end = System.currentTimeMillis();
+            _mLogger.log("Assigned Screens", screens.size());
             _mTimeLogger.log("Time taken for processing screenshot files in background =", (end-start));
             ScreenFactory.getInstance().analyzeScreens(screens);
         } catch (Exception e) {


### PR DESCRIPTION
1. For  system screenshots that do not have which app information in their name,
   usage events is fetched for last month, and based on the screenshot creation
   time stamp and usage events time stamp, appropriate foreground app at the time of
   screenshot creation is inferred.
2. Moved all comparator functions to SortHelper.kt to avoid repition of code

Signed-off-by: pavan142 <pa1tirumani@gmail.com>