### PR TITLE
Added database support for appnames

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/database/DatabaseManager.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/DatabaseManager.java
@@ -3,6 +3,7 @@ package com.frankenstein.screenx.database;
 import android.content.Context;
 
 import androidx.room.Room;
+import androidx.room.migration.Migration;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
 import static com.frankenstein.screenx.Constants.DB_NAME;
@@ -10,10 +11,19 @@ import static com.frankenstein.screenx.Constants.DB_NAME;
 public class DatabaseManager {
     private static ScreenShotDatabase _mInstance;
 
+    static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE ScreenShotEntity "
+                    + " ADD COLUMN appname TEXT");
+        }
+    };
+
     public static ScreenShotDatabase getInstance(Context context) {
         if (_mInstance == null) {
             // TODO: Remove the fallbackToDestructiveMigration once the database design iterations are finalized, and proper migrations could be defined later on
-            _mInstance = Room.databaseBuilder(context, ScreenShotDatabase.class, DB_NAME).fallbackToDestructiveMigration().build();
+            _mInstance = Room.databaseBuilder(context, ScreenShotDatabase.class, DB_NAME)
+                    .addMigrations(MIGRATION_1_2).build();
         }
         return _mInstance;
     }

--- a/app/src/main/java/com/frankenstein/screenx/database/FtsEntity.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/FtsEntity.java
@@ -10,4 +10,3 @@ public class FtsEntity {
     @ColumnInfo(name = "text_content")
     public String textContent;
 }
-

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
@@ -3,22 +3,32 @@ package com.frankenstein.screenx.database;
 import java.util.List;
 
 import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.Update;
 
 @Dao
 public interface ScreenShotDao {
-
-    @Query("INSERT INTO ScreenShotEntity (filename, text_content, meta_data) values(:filename, :textContent, :metaData)")
-    void putScreenShot(String filename, String textContent, String metaData);
-
-    @Query("UPDATE ScreenShotEntity SET text_content= :textContent WHERE filename = :filename")
-    void updateScreenShotText(String filename, String textContent);
 
     @Query("SELECT * FROM ScreenShotEntity")
     List<ScreenShotEntity> getAll();
 
     @Query ("SELECT * FROM ScreenShotEntity INNER JOIN fts ON ScreenShotEntity.`rowid` = fts.`rowid` WHERE fts.text_content MATCH :query")
     List<ScreenShotEntity> findByContent(String query);
+
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public void insertScreenshots(List<ScreenShotEntity> screenShotEntityList);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public void insertSingleScreenshot(ScreenShotEntity entity);
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    public void updateScreenshots(List<ScreenShotEntity> screenShotEntityList);
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    public void updateSingleScreenshot(ScreenShotEntity entity);
 
     @Query("SELECT * FROM ScreenShotEntity WHERE filename LIKE :filename")
     ScreenShotEntity getScreenShotByName(String filename);

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDatabase.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDatabase.java
@@ -3,7 +3,7 @@ package com.frankenstein.screenx.database;
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
 
-@Database(entities = {ScreenShotEntity.class, FtsEntity.class}, version = 1)
+@Database(entities = {ScreenShotEntity.class, FtsEntity.class}, version = 2)
 public abstract class ScreenShotDatabase extends RoomDatabase {
     public abstract ScreenShotDao screenShotDao();
 }

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotEntity.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotEntity.java
@@ -10,6 +10,9 @@ public class ScreenShotEntity {
     @PrimaryKey @NonNull
     public String filename;
 
+    @ColumnInfo(name="appname")
+    public String appname;
+
     @ColumnInfo(name="text_content")
     public String textContent;
 

--- a/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
@@ -115,21 +115,22 @@ public class AppHelper {
         return appName;
     }
 
-    public static ArrayList<Screenshot> GetMultipleScreens(Context context, ArrayList<File> files) {
-        ArrayList <Screenshot> screens = new ArrayList<>();
+    public static ArrayList<Screenshot> LabelMultipleScreens(ArrayList<Screenshot> screens, Context context, ArrayList<File> files) {
+        ArrayList <Screenshot> newlyLabelledScreens = new ArrayList<>();
         ArrayList <Screenshot> nullAppScreens = new ArrayList<>();
         for (File file: files) {
             String fileName = file.getName();
             String appName = getSourceApp(context, fileName);
             Screenshot screen = new Screenshot(fileName, file.getAbsolutePath(), appName);
             screens.add(screen);
+            newlyLabelledScreens.add(screen);
             if (appName == null) {
                 nullAppScreens.add(screen);
             }
         }
         _mLogger.log("NullAppScreens Length", nullAppScreens.size());
         assignAppNamesViaUsageEvents(context, nullAppScreens);
-        return screens;
+        return newlyLabelledScreens;
     }
 
 

--- a/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
+++ b/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
@@ -3,14 +3,18 @@ package com.frankenstein.screenx.multithreading;
 import android.os.AsyncTask;
 import android.content.Context;
 
+import com.frankenstein.screenx.ScreenXApplication;
+import com.frankenstein.screenx.database.ScreenShotEntity;
 import com.frankenstein.screenx.helper.Logger;
-import com.frankenstein.screenx.ScreenFactory;
 import com.frankenstein.screenx.models.Screenshot;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static com.frankenstein.screenx.helper.AppHelper.GetMultipleScreens;
+import static com.frankenstein.screenx.helper.AppHelper.LabelMultipleScreens;
 import static com.frankenstein.screenx.helper.FileHelper.getAllScreenshotFiles;
 
 public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Screenshot>> {
@@ -30,11 +34,31 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
         ArrayList<Screenshot> screens = new ArrayList<>();
         try {
             ArrayList<File> files = getAllScreenshotFiles();
-            screens = GetMultipleScreens(context, files);
+
+            List<ScreenShotEntity> existingEntities = ScreenXApplication.textHelper.getAllScreenshotsInDatabase();
+            Map<String, ScreenShotEntity> existingEntitiesMap = new HashMap<>();
+            for (ScreenShotEntity entity: existingEntities)
+                existingEntitiesMap.put(entity.filename, entity);
+
+            ArrayList<File> filesToBeLabeled = new ArrayList<>();
+
+            for (File file: files) {
+                ScreenShotEntity entity = existingEntitiesMap.get(file.getName());
+                if (entity == null || entity.appname == null)
+                    filesToBeLabeled.add(file);
+                else {
+                    Screenshot newSreen = new Screenshot(entity.filename, file.getPath(), entity.appname);
+                    screens.add(newSreen);
+                }
+            }
+            ArrayList<Screenshot> newlyLabelledscreens = LabelMultipleScreens(screens, context, filesToBeLabeled);
             Long end = System.currentTimeMillis();
-            _mLogger.log("Assigned Screens", screens.size());
+            _mLogger.log("Total Screens", screens.size(), "Existing Screens",
+                    screens.size() - newlyLabelledscreens.size(),
+                    "Newly Labelled Screens", newlyLabelledscreens.size());
             _mTimeLogger.log("Time taken for processing screenshot files in background =", (end-start));
-            ScreenFactory.getInstance().analyzeScreens(screens);
+            ScreenXApplication.screenFactory.analyzeScreens(screens);
+            ScreenXApplication.textHelper.updateAppNames(newlyLabelledscreens);
         } catch (Exception e) {
             _mLogger.log("got an error: ", e.getMessage());
         }


### PR DESCRIPTION
1. Added appname column to screenshot table.
2. This will help in improving recognition of system screenshots and screenshots of uninstalled apps better.
3. For system screenshots currently we are doing usage event query and looking for timestamp match, but
   as the screenshot ages, the creation timestamp of screenshot will move out of the query time interval.
   But with this CL, once we label the screenshot properly, we don't have to label it again, as the
   data is persisted in the database.
4. And regarding screenshots of uninstalled apps, once the screenshot is labelled and stored the appname
   in the database, it does not matter any more if the source app is uninstalled. As we don't query
   package manager for installed applications and get screenshot label anymore, instead we directly
   retrieve the data from the database.

Closes #63 

Signed-off-by: pavan142 <pa1tirumani@gmail.com>