### PR TITLE
Speed up of refresh of screenshots

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
@@ -2,6 +2,7 @@ package com.frankenstein.screenx.database;
 
 import java.util.List;
 
+import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
@@ -13,6 +14,9 @@ public interface ScreenShotDao {
 
     @Query("SELECT * FROM ScreenShotEntity")
     List<ScreenShotEntity> getAll();
+
+    @Query("SELECT * FROM ScreenShotEntity")
+    LiveData<List<ScreenShotEntity>> getLiveAll();
 
     @Query ("SELECT * FROM ScreenShotEntity INNER JOIN fts ON ScreenShotEntity.`rowid` = fts.`rowid` WHERE fts.text_content MATCH :query")
     List<ScreenShotEntity> findByContent(String query);

--- a/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/AppHelper.java
@@ -60,6 +60,8 @@ public class AppHelper {
     }
 
     private static void assignAppNamesViaUsageEvents(Context context, ArrayList<Screenshot> screens) {
+        if (screens.size() == 0)
+            return;
         _mLogger.log("Starting assignAppNamesViaUsageEvents");
         UsageStatsManager usm = (UsageStatsManager) context.getSystemService(Context.USAGE_STATS_SERVICE);
         PackageManager pm = context.getPackageManager();

--- a/app/src/main/java/com/frankenstein/screenx/helper/Logger.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/Logger.java
@@ -23,55 +23,39 @@ public class Logger {
         return instanceMap.get(tag);
     }
 
-    private Logger(String tag) {
+    protected Logger(String tag) {
         this.tag = tag;
     }
 
-    public void d(Object... args) {
+    protected String joinArgs(Object... args) {
         String message = "";
         for (int i = 0; i < args.length; i++) {
             message += args[i] + "\t";
-        }
-        Log.d(this.tag, message);
+        };
+        return message;
+    }
+
+    public void d(Object... args) {
+        Log.d(this.tag, joinArgs(args));
     }
 
     public void i(Object... args) {
-        String message = "";
-        for (int i = 0; i < args.length; i++) {
-            message += args[i] + "\t";
-        }
-        Log.i(this.tag, message);
+        Log.i(this.tag, joinArgs(args));
     }
 
     public void w(Object... args) {
-        String message = "";
-        for (int i = 0; i < args.length; i++) {
-            message += args[i] + "\t";
-        }
-        Log.w(this.tag, message);
+        Log.w(this.tag, joinArgs(args));
     }
 
     public void v(Object... args) {
-        String message = "";
-        for (int i = 0; i < args.length; i++) {
-            message += args[i] + "\t";
-        }
-        Log.v(this.tag, message);
+        Log.v(this.tag, joinArgs(args));
     }
 
     public void e(Object... args) {
-        String message = "";
-        for (int i = 0; i < args.length; i++) {
-            message += args[i] + "\t";
-        }
-        Log.e(this.tag, message);
+        Log.e(this.tag, joinArgs(args));
     }
 
     public void log(Object... args) {
-        String message = "";
-        for (int i = 0; i < args.length; i++) {
-            message += args[i] + "\t";
-        }
-        Log.i(this.tag, message);
+        Log.i(this.tag, joinArgs(args));
     }
 }

--- a/app/src/main/java/com/frankenstein/screenx/helper/TimeLogger.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/TimeLogger.java
@@ -1,0 +1,55 @@
+package com.frankenstein.screenx.helper;
+
+import java.util.HashMap;
+import java.util.Map;
+import android.util.Log;
+
+public class TimeLogger extends Logger {
+    private String tag;
+    private static final  TimeLogger _mInstance = new TimeLogger();
+    private static final String TIME_TAG = "SCREENX-TIME";
+
+    private final long _mStart = System.currentTimeMillis();
+    private long _mPrevTime;
+    public static TimeLogger getInstance() {
+         return _mInstance;
+    }
+
+    private TimeLogger() {
+        super(TIME_TAG);
+        _mPrevTime = System.currentTimeMillis();
+    }
+
+    private String getTimeString() {
+        long currTime = System.currentTimeMillis();
+        long delta = currTime - _mPrevTime;
+        _mPrevTime = currTime;
+        String timePassed = "@" + (currTime - _mStart)+ "ms" + "\t";
+        timePassed += "~" + delta + "ms";
+        return timePassed;
+    }
+
+    public void d(Object ... args) {
+        super.d(getTimeString(),  joinArgs(args));
+    }
+
+    public void i(Object... args) {
+        super.i(getTimeString(),  joinArgs(args));
+    }
+
+    public void w(Object... args) {
+        super.w(getTimeString(),  joinArgs(args));
+    }
+
+    public void v(Object... args) {
+        super.v(getTimeString(),  joinArgs(args));
+    }
+
+    public void e(Object... args) {
+        super.e(getTimeString(),  joinArgs(args));
+    }
+
+    public void log(Object... args) {
+        super.i(getTimeString(),  joinArgs(args));
+    }
+}

--- a/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
+++ b/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
@@ -4,8 +4,10 @@ import android.os.AsyncTask;
 import android.content.Context;
 
 import com.frankenstein.screenx.ScreenXApplication;
+import com.frankenstein.screenx.Utils;
 import com.frankenstein.screenx.database.ScreenShotEntity;
 import com.frankenstein.screenx.helper.Logger;
+import com.frankenstein.screenx.helper.TimeLogger;
 import com.frankenstein.screenx.models.Screenshot;
 
 import java.io.File;
@@ -20,7 +22,7 @@ import static com.frankenstein.screenx.helper.FileHelper.getAllScreenshotFiles;
 public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Screenshot>> {
 
     private Logger _mLogger = Logger.getInstance("GetScreensAsyncTask");;
-    private static final Logger _mTimeLogger = Logger.getInstance("TIME");
+    private static final Logger _mTimeLogger = TimeLogger.getInstance();
 
     public GetScreensAsyncTask() {
         super();
@@ -29,14 +31,16 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
     @Override
     protected ArrayList<Screenshot> doInBackground(Object ...objects) {
         Long start = System.currentTimeMillis();
-        _mLogger.log("doInBackground", Thread.currentThread().toString());
+        _mTimeLogger.log("GetScreensAsyncTask: doInBackground");
         final Context context = (Context) objects[0];
         ArrayList<Screenshot> screens = new ArrayList<>();
         try {
             ArrayList<File> files = getAllScreenshotFiles();
+            _mTimeLogger.d("Scanned all screenshot files");
 
             List<ScreenShotEntity> existingEntities = ScreenXApplication.textHelper.getAllScreenshotsInDatabase();
             Map<String, ScreenShotEntity> existingEntitiesMap = new HashMap<>();
+            _mTimeLogger.d("Fetched all the existing screenshots from database");
             for (ScreenShotEntity entity: existingEntities)
                 existingEntitiesMap.put(entity.filename, entity);
 
@@ -51,9 +55,12 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
                     screens.add(newSreen);
                 }
             }
+            _mTimeLogger.d("Sending unlabelled screens for labelling");
+
             ArrayList<Screenshot> newlyLabelledscreens = LabelMultipleScreens(screens, context, filesToBeLabeled);
+            _mTimeLogger.d("Finished labelling", Thread.currentThread().toString());
             Long end = System.currentTimeMillis();
-            _mLogger.log("Total Screens", screens.size(), "Existing Screens",
+            _mTimeLogger.log("Total Screens", screens.size(), "Existing Screens",
                     screens.size() - newlyLabelledscreens.size(),
                     "Newly Labelled Screens", newlyLabelledscreens.size());
             _mTimeLogger.log("Time taken for processing screenshot files in background =", (end-start));


### PR DESCRIPTION
1. GetScreensAsyncTask does not make a db call everytime a refresh is initiated,
   but only the first time, all subsequent times, the latest existing screenshots
   in database is direclty returned. This is achieved by having an observer on
   livedata on "Select * FROM ScreenshotEntity" query, this automatically updates
   existing screenshots everytime there is a change. So whenever GetScreensAsyncTask
   is invoked, this latest data is returned.

2. This CL also adds very useful time logger for debugging delays

Signed-off-by: pavan142 <pa1tirumani@gmail.com>