### PR TITLE
Added support for live detection of system Screenshots

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
+++ b/app/src/main/java/com/frankenstein/screenx/ScreenFactory.java
@@ -6,16 +6,24 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import android.content.Context;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.provider.MediaStore;
 
 import com.frankenstein.screenx.helper.Logger;
-import com.frankenstein.screenx.helper.SortHelper;
+import com.frankenstein.screenx.helper.PermissionHelper;
+import com.frankenstein.screenx.helper.TimeLogger;
 import com.frankenstein.screenx.models.AppGroup;
 import com.frankenstein.screenx.models.Screenshot;
 import com.frankenstein.screenx.multithreading.GetScreensAsyncTask;
 
 import androidx.lifecycle.MutableLiveData;
 
-import static com.frankenstein.screenx.helper.AppHelper.GetScreenFromFile;
+import static com.frankenstein.screenx.helper.AppHelper.processNewScreen;
 import static com.frankenstein.screenx.helper.SortHelper.DESC_TIME;
 
 public class ScreenFactory {
@@ -30,12 +38,18 @@ public class ScreenFactory {
 
     private boolean _initialized = false;
     private final Logger _logger = Logger.getInstance("ScreenFactory");
-    private static final Logger _mTimeLogger = Logger.getInstance("TIME");
+    private static final Logger _mTimeLogger = TimeLogger.getInstance();
+    private boolean _monitoring = false;
+    private Handler _monitorHandler;
+    private Handler _mainHandler;
+    private HandlerThread _monitorThread;
+    private Context _context;
+    private static final String MONITOR_THREAD_NAME = "MONITOR_THREAD_NAME";
 
     public static ScreenFactory init(Context context) {
         if (_instance != null)
             return _instance;
-        _instance = new ScreenFactory();
+        _instance = new ScreenFactory(context);
         return _instance;
     }
 
@@ -43,7 +57,14 @@ public class ScreenFactory {
         return _instance;
     }
 
-    private ScreenFactory() {}
+    private ScreenFactory(Context context) {
+        _context = context;
+        _monitorThread = new HandlerThread(MONITOR_THREAD_NAME);
+        _monitorThread.start();
+        _monitorHandler = new Handler(_monitorThread.getLooper());
+        _mainHandler = new Handler(Looper.getMainLooper());
+        startMonitor();
+    }
 
     public void analyzeScreens(ArrayList<Screenshot> screens) {
         Long start = System.currentTimeMillis();
@@ -124,18 +145,27 @@ public class ScreenFactory {
 
     }
 
-    public void onScreenAdded(Context context,String filepath) {
-        _logger.log("ScreenFactory: onScreenAdded", filepath);
-        File file = new File(filepath);
-        Screenshot screen = GetScreenFromFile(context, file);
-        addScreen(screen);
+    public void onScreenAdded(Context context, String filepath) {
+        _monitorHandler.post(() -> {
+            _logger.log("ScreenFactory: onScreenAdded", filepath);
+            File file = new File(filepath);
+            if (nameToScreen.containsKey(file.getName())) {
+                _logger.log("new screen already exists", filepath);
+                return;
+            }
+            Screenshot screen = processNewScreen(context, file);
+            addScreen(screen);
+            ScreenXApplication.textHelper.updateScreenAppName(screen);
+            ArrayList<Screenshot> newScreenshots = screenshots.getValue();
+            newScreenshots.add(screen);
 
-        ArrayList<Screenshot> newScreenshots = screenshots.getValue();
-        newScreenshots.add(screen);
+            sort();
+            _logger.log("Posting Screenshots value to livedata on UI Thread");
 
-        sort();
-        _logger.log("Posting Screenshots value to livedata on UI Thread");
-        screenshots.postValue(newScreenshots);
+            _mainHandler.post(() -> {
+                screenshots.postValue(newScreenshots);
+            });
+        });
     }
 
     public ArrayList<AppGroup> getAppGroups(Utils.SortingCriterion sort) {
@@ -170,5 +200,53 @@ public class ScreenFactory {
         _logger.log("received refresh request", Thread.currentThread().toString());
         _initialized = false;
         this.loadScreens(context);
+        this.startMonitor();
+    }
+
+    public void startMonitor() {
+        if (_monitoring)
+            return;
+        _monitoring = true;
+        _logger.log("Starting Image Monitoring");
+        _context.getContentResolver().registerContentObserver(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true,
+                new ContentObserver(_monitorHandler) {
+                    @Override
+                    public void onChange(boolean selfChange, Uri uri) {
+                        if (uri == null)
+                            return;
+                        _logger.log("New Image Detected", uri.toString(), MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+                        super.onChange(selfChange);
+
+                        if (!PermissionHelper.hasStoragePermission(_context))
+                            return;
+
+                        if (!uri.toString().contains(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())) {
+                            return;
+                        }
+
+                        Cursor cursor =  _context.getContentResolver().query(uri,
+                                new String[]{MediaStore.Images.Media.DISPLAY_NAME,
+                                        MediaStore.Images.Media.DATA,
+                                        MediaStore.Images.Media.DATE_ADDED},
+                                null,
+                                null,
+                                MediaStore.Images.Media.DATE_ADDED + " DESC"
+                        );
+                        if (cursor.moveToFirst()) {
+                            String path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA));
+                            if (isScreenshot(path)) {
+                                _logger.log("It's a screenshot", path);
+                                onScreenAdded(_context, path);
+                            }
+                        }
+                    }
+                }
+        );
+    }
+
+    private boolean isScreenshot(String path) {
+        File file = new File(path);
+        return (file.getAbsolutePath().contains("Screenshot") ||
+                file.getAbsolutePath().contains("screenshot"));
     }
 }

--- a/app/src/main/java/com/frankenstein/screenx/coroutines/ParserCoroutine.kt
+++ b/app/src/main/java/com/frankenstein/screenx/coroutines/ParserCoroutine.kt
@@ -81,7 +81,7 @@ class ParserCoroutine(): CoroutineScope {
 
     suspend fun saveToDatabase(filename: String, text: String) {
         withContext(Dispatchers.IO) {
-            ScreenXApplication.textHelper.putScreenIntoDB(filename, text);
+            ScreenXApplication.textHelper.updateScreenText(filename, text);
         }
     }
 

--- a/app/src/main/java/com/frankenstein/screenx/helper/UsageStatsHelper.kt
+++ b/app/src/main/java/com/frankenstein/screenx/helper/UsageStatsHelper.kt
@@ -46,19 +46,13 @@ class UsageStatsHelper {
         }
 
         @JvmStatic
-        fun getArchivedFgEventTimeline(usm: UsageStatsManager): ArrayList<ForeGroundAppEvent> {
+        fun getFgEventTimeline(usm: UsageStatsManager, isLive: Boolean): ArrayList<ForeGroundAppEvent> {
             var calendar = Calendar.getInstance()
             val endTime = calendar.timeInMillis
-            calendar.add(Calendar.MONTH, -1)
-            val startTime = calendar.timeInMillis
-            return filterFgEvents(usm, startTime, endTime);
-        }
-
-        @JvmStatic
-        fun getLiveFgEventTimeline(usm: UsageStatsManager): ArrayList<ForeGroundAppEvent> {
-            var calendar = Calendar.getInstance()
-            val endTime = calendar.timeInMillis
-            calendar.add(Calendar.HOUR, -1)
+            if (isLive)
+                calendar.add(Calendar.HOUR, -1)
+            else
+                calendar.add(Calendar.MONTH, -1)
             val startTime = calendar.timeInMillis
             return filterFgEvents(usm, startTime, endTime);
         }


### PR DESCRIPTION
1. Using content observer to see if any new image is added. If the image is a screenshot,
   the file is sent for further processing. If the filename contains packageId or appName
   info already, app name is labelled directly. Otherwise, the source app is inferred using
   usage events by matching the screenshot timestamp with foreground app at that time.
2. With this patch, the requirement of floating screenshot button has become optional.
   As the user could just take system screenshots the way he prefers, and they would
   be categorized by their source apps appropriately

Signed-off-by: pavan142 <pa1tirumani@gmail.com>