### PR TITLE
Fixed scroll issue while navigating back to home page

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/AppGroupActivity.java
@@ -14,6 +14,8 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import java.util.ArrayList;
 
+import static com.frankenstein.screenx.helper.ArrayHelper.Same;
+
 public class AppGroupActivity extends MultipleSelectActivity {
 
     private Logger _logger;
@@ -57,16 +59,7 @@ public class AppGroupActivity extends MultipleSelectActivity {
             finish();
             return;
         }
-        boolean sameData = ag.screenshots.size() == mScreens.size();
-        if (sameData) {
-            for (int i = 0; i < ag.screenshots.size(); i++) {
-                if (!ag.screenshots.get(i).name.equals(mScreens.get(i).name)) {
-                    sameData = false;
-                    break;
-                }
-            }
-        }
-        if (sameData)
+        if (Same(ag.screenshots, mScreens))
             return;
         mScreens = (ArrayList<Screenshot>) ag.screenshots.clone();
         _logger.log("Displaying Scrrens of Appgroup", _appName, mScreens.size());

--- a/app/src/main/java/com/frankenstein/screenx/MainActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/MainActivity.java
@@ -34,6 +34,7 @@ import com.frankenstein.screenx.ui.PermissionComponentView;
 import com.frankenstein.screenx.ui.adapters.HomePageAdapter;
 
 import static com.frankenstein.screenx.Constants.PROGRESSBAR_TRANSITION;
+import static com.frankenstein.screenx.helper.ArrayHelper.Same;
 import static com.frankenstein.screenx.helper.FileHelper.CUSTOM_SCREENSHOT_DIR;
 import static com.frankenstein.screenx.helper.FileHelper.createIfNot;
 
@@ -59,6 +60,9 @@ public class MainActivity extends AppCompatActivity {
     private View _mHomePageContentLayout;
     private View _mHomePageContentEmpty;
     private View _mHomePageDisplayContent;
+
+    private ArrayList<Screenshot> _mAppgroupMascots = new ArrayList<>();
+    private ArrayList<Integer> _mAppgroupSizes = new ArrayList<>();
 
     private MutableLiveData<HomePageState> _mState = new MutableLiveData<>();
     private HomePageState _mPrevState = HomePageState.REQUEST_PERMISSIONS;
@@ -257,6 +261,7 @@ public class MainActivity extends AppCompatActivity {
     public void attachAdapter() {
         _mLogger.log("attaching adapter");
         ArrayList<Screenshot> mascots = new ArrayList<>();
+        ArrayList<Integer> appgroupSizes = new ArrayList<>();
         Utils.SortingCriterion criterion = (_mSortByDate) ? Utils.SortingCriterion.Date: Utils.SortingCriterion.Alphabetical;
         ArrayList<AppGroup> appgroups = ScreenXApplication.screenFactory.getAppGroups(criterion);
         if (appgroups.size() == 0) {
@@ -267,11 +272,16 @@ public class MainActivity extends AppCompatActivity {
 
         _mState.setValue(HomePageState.DISPLAY_CONTENT);
 
-        for (AppGroup ag : appgroups)
+        for (AppGroup ag : appgroups) {
             mascots.add(ag.mascot);
-//        for (Screenshot s : mascots)
-//            _mLogger.log(s.appName, s.name);
-        _adapter = new HomePageAdapter(getApplicationContext(), mascots);
+            appgroupSizes.add(ag.screenshots.size());
+        }
+
+        if (Same(mascots, _mAppgroupMascots) && Same(appgroupSizes, _mAppgroupSizes))
+            return;
+        _mAppgroupMascots = mascots;
+        _mAppgroupSizes = appgroupSizes;
+        _adapter = new HomePageAdapter(getApplicationContext(), _mAppgroupMascots);
         _mGridView.setAdapter(_adapter);
         _mGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override

--- a/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 
 import androidx.lifecycle.LiveData;
 
+import static com.frankenstein.screenx.helper.ArrayHelper.Same;
+
 public class SearchActivity extends MultipleSelectActivity {
 
     private AppCompatAutoCompleteTextView _mSearch;
@@ -76,17 +78,7 @@ public class SearchActivity extends MultipleSelectActivity {
             if (screen != null)
                 newScreens.add(screen);
         }
-        boolean sameData = newScreens.size() == mScreens.size();
-        if (sameData) {
-            for (int i = 0; i < newScreens.size(); i++) {
-                if (!newScreens.get(i).name.equals(mScreens.get(i).name)) {
-                    sameData = false;
-                    break;
-                }
-            }
-        }
-        if (sameData)
-            return;
+        if (Same(newScreens, mScreens))
 
         mScreens = newScreens;
         _mMatches = matches;

--- a/app/src/main/java/com/frankenstein/screenx/helper/ArrayHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/ArrayHelper.java
@@ -1,0 +1,23 @@
+package com.frankenstein.screenx.helper;
+
+import com.frankenstein.screenx.models.Screenshot;
+import com.frankenstein.screenx.overlay.Screen;
+
+import java.util.ArrayList;
+
+public class ArrayHelper {
+    public static boolean Same(ArrayList<? extends Object> arr1, ArrayList<? extends Object> arr2) {
+
+        boolean sameData = arr1.size() == arr2.size();
+        if (sameData) {
+            for (int i = 0; i < arr1.size(); i++) {
+                if (!arr1.get(i).equals(arr2.get(i))) {
+                    sameData = false;
+                    break;
+                }
+            }
+        }
+
+        return sameData;
+    }
+}

--- a/app/src/main/java/com/frankenstein/screenx/models/Screenshot.java
+++ b/app/src/main/java/com/frankenstein/screenx/models/Screenshot.java
@@ -1,8 +1,11 @@
 package com.frankenstein.screenx.models;
 
 import com.frankenstein.screenx.interfaces.TimeSortable;
+import com.frankenstein.screenx.overlay.Screen;
 
 import java.io.File;
+
+import androidx.annotation.Nullable;
 
 public class Screenshot extends TimeSortable {
     public String name;
@@ -16,5 +19,13 @@ public class Screenshot extends TimeSortable {
         this.filePath = filePath;
         this.file = new File(filePath);
         this.lastModified = this.file.lastModified();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof Screenshot))
+            return false;
+        Screenshot s = (Screenshot) obj;
+        return this.name.equals(s.name);
     }
 }


### PR DESCRIPTION
1. When you come back to home page, list of screenshots is refreshed, which was
   updating homepage grid's adapter.So when the user comes back to home page, due to
   grid view refresh, the scroll is reset to top. Now added an equality check for grid data before
   resetting grid's adapter

Signed-off-by: pavan142 <pa1tirumani@gmail.com>