### PR TITLE
This patch speeds up search significantly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.frankenstein.screenx"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 9
-        versionName "1.5.2-perf-baseline"
+        versionCode 10
+        versionName "1.6.0-search-baseline"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
@@ -14,6 +14,7 @@ import com.google.firebase.perf.FirebasePerformance;
 import com.google.firebase.perf.metrics.Trace;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import androidx.lifecycle.LiveData;
 
@@ -23,8 +24,8 @@ public class SearchActivity extends MultipleSelectActivity {
 
     private AppCompatAutoCompleteTextView _mSearch;
     private final Logger _mLogger = Logger.getInstance("SearchActivity");
-    private LiveData<ArrayList<String>> _mLiveMatches = new LiveData<ArrayList<String>>() {};
-    private ArrayList<String> _mMatches;
+    private LiveData<List<String>> _mLiveMatches = new LiveData<List<String>>() {};
+    private ArrayList<String> _mMatches = new ArrayList<>();
     private ImageButton _mClearSearch;
     private Trace _mSearchTrace;
 
@@ -67,24 +68,25 @@ public class SearchActivity extends MultipleSelectActivity {
         }
     }
 
-    public void onLiveMatches(ArrayList<String> matches) {
+    public void onLiveMatches(List<String> matches) {
         _mSearchTrace.stop();
         _mLogger.log("number of matches", matches.size());
         updateAdapter(matches);
     }
 
-    private void updateAdapter(ArrayList<String> matches) {
+    private void updateAdapter(List<String> matches) {
         ArrayList<Screenshot> newScreens = new ArrayList<>();
-        for (int i = 0; i < matches.size(); i++) {
-            _mLogger.log("Matched", matches.get(i));
-            Screenshot screen = ScreenXApplication.screenFactory.findScreenByName(matches.get(i));
-            if (screen != null)
+        _mMatches.clear();
+        for (String filename: matches) {
+            Screenshot screen = ScreenXApplication.screenFactory.findScreenByName(filename);
+            if (screen != null) {
                 newScreens.add(screen);
+                _mMatches.add(filename);
+            }
         }
         if (Same(newScreens, mScreens))
             return;
         mScreens = newScreens;
-        _mMatches = matches;
         _mLogger.log("Displaying grid with items = ", mScreens.size());
         super.updateAdapter();
     }

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
@@ -18,9 +18,8 @@ public interface ScreenShotDao {
     @Query("SELECT * FROM ScreenShotEntity")
     LiveData<List<ScreenShotEntity>> getLiveAll();
 
-    @Query ("SELECT * FROM ScreenShotEntity INNER JOIN fts ON ScreenShotEntity.`rowid` = fts.`rowid` WHERE fts.text_content MATCH :query")
-    List<ScreenShotEntity> findByContent(String query);
-
+    @Query ("SELECT filename FROM ScreenShotEntity INNER JOIN fts ON ScreenShotEntity.`rowid` = fts.`rowid` WHERE fts.text_content MATCH :query")
+    LiveData<List<String>> findByContent(String query);
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     public void insertScreenshots(List<ScreenShotEntity> screenShotEntityList);

--- a/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
+++ b/app/src/main/java/com/frankenstein/screenx/helper/TextHelper.java
@@ -125,25 +125,8 @@ public class TextHelper {
         return unParsedScreens;
     }
 
-    public LiveData<ArrayList<String>> searchScreenshots(String text) {
-        MutableLiveData<ArrayList<String>> livescreens = new MutableLiveData<>();
-        // This method is invoked by Main Thread, so we need to post the database operations
-        // on to a separate thread
-        _mDBHandler.post(() -> {
-            // LIKE uses %query% format for pattern matching and
-            // MATCH uses *query* format for pattern matching
-            List<ScreenShotEntity> matchedList = _mDBClient.screenShotDao().findByContent("*"+text+"*");
-            ArrayList<String> screens = new ArrayList<>();
-            _mLogger.log("Total matched screenshots by search = ", matchedList.size());
-            for (int i = 0; i < matchedList.size(); i++) {
-                ScreenShotEntity item = matchedList.get(i);
-                if (ScreenXApplication.screenFactory.findScreenByName(item.filename) != null)
-                    screens.add(item.filename);
-            }
-            DESC_SCREENS_BY_TIME(screens);
-            livescreens.postValue(screens);
-        });
-        return livescreens;
+    public LiveData<List<String>> searchScreenshots(String text) {
+        return _mDBClient.screenShotDao().findByContent("*" + text + "*");
     }
 
     public String textByFilenameDB(String filename) {


### PR DESCRIPTION
1.Before:: While finding the search query in database, the entire rows were
  returned, which was very costly operation when there are too many rows.
  Mainly because the rows contain the text content column too. So for queries
  that return large number of rows, like single letter query (which happens when
  you start typing), the results were very slow in some cases.

  Now:: Instead of getting entire matched rows from the database, only filenames
  are returned, as that is what we only need anyway, we have all the other information
  about the screenshot with screenfactory

2. Changed build version to 10 (Version name to `1.6.0-search-baseline`)

Closes #75

Signed-off-by: pavan142 <pa1tirumani@gmail.com>