### PR TITLE
Speed up home page loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.frankenstein.screenx"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 10
-        versionName "1.6.0-search-baseline"
+        versionCode 11
+        versionName "1.7.0-db-loading-baseline"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
+++ b/app/src/main/java/com/frankenstein/screenx/database/ScreenShotDao.java
@@ -12,11 +12,20 @@ import androidx.room.Update;
 @Dao
 public interface ScreenShotDao {
 
-    @Query("SELECT * FROM ScreenShotEntity")
+      // As this query returns the entire row, this would contain the text_content column too
+      // which makes this a very costly operation. So disabling it, as there is no need in current flows
+      // to get text_content of all rows in a single query.
+//    @Query("SELECT * FROM ScreenShotEntity")
+//    List<ScreenShotEntity> getAllWithTextContent();
+
+    @Query("SELECT filename, appname FROM ScreenShotEntity")
     List<ScreenShotEntity> getAll();
 
-    @Query("SELECT * FROM ScreenShotEntity")
+    @Query("SELECT filename, appname FROM ScreenShotEntity")
     LiveData<List<ScreenShotEntity>> getLiveAll();
+
+    @Query("SELECT filename, appname FROM ScreenShotEntity WHERE text_content IS NOT NULL")
+    List<ScreenShotEntity> getAllParsed();
 
     @Query ("SELECT filename FROM ScreenShotEntity INNER JOIN fts ON ScreenShotEntity.`rowid` = fts.`rowid` WHERE fts.text_content MATCH :query")
     LiveData<List<String>> findByContent(String query);

--- a/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
+++ b/app/src/main/java/com/frankenstein/screenx/multithreading/GetScreensAsyncTask.java
@@ -30,7 +30,7 @@ public class GetScreensAsyncTask extends AsyncTask<Object, Void, ArrayList<Scree
 
     @Override
     protected ArrayList<Screenshot> doInBackground(Object ...objects) {
-        _mLogger.log("GetScreensAsyncTask: doInBackground");
+        _mLogger.log("doInBackground");
         final Context context = (Context) objects[0];
         ArrayList<Screenshot> screens = new ArrayList<>();
         try {


### PR DESCRIPTION
1. As the old getAll database query returned the entire row, this would contain the text_content column too
   which makes it a very costly operation. So instead replaced it with getAll which only returns
   filename and appname in the data, making database fetch operations quicker.

2. Changed Build version to 11 (and version name to `1.7.0-db-loading-baseline`

Closes #33

Signed-off-by: pavan142 <pa1tirumani@gmail.com>