### PR TITLE
[fixup] This patch speeds up search significantly

### DIFF
--- a/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
+++ b/app/src/main/java/com/frankenstein/screenx/SearchActivity.java
@@ -19,6 +19,7 @@ import java.util.List;
 import androidx.lifecycle.LiveData;
 
 import static com.frankenstein.screenx.helper.ArrayHelper.Same;
+import static com.frankenstein.screenx.helper.SortHelper.DESC_SCREENS_BY_TIME;
 
 public class SearchActivity extends MultipleSelectActivity {
 
@@ -71,6 +72,7 @@ public class SearchActivity extends MultipleSelectActivity {
     public void onLiveMatches(List<String> matches) {
         _mSearchTrace.stop();
         _mLogger.log("number of matches", matches.size());
+        DESC_SCREENS_BY_TIME(matches);
         updateAdapter(matches);
     }
 

--- a/app/src/main/java/com/frankenstein/screenx/helper/SortHelper.kt
+++ b/app/src/main/java/com/frankenstein/screenx/helper/SortHelper.kt
@@ -23,7 +23,7 @@ public class SortHelper {
         }
 
         @JvmStatic
-        fun DESC_SCREENS_BY_TIME(input: ArrayList<String>) {
+        fun DESC_SCREENS_BY_TIME(input: MutableList<String>) {
             input.sortByDescending{it -> ScreenXApplication.screenFactory.findScreenByName(it).lastModified}
         }
 


### PR DESCRIPTION
1. The search speedup match (#79) broke the sorting of search results by time.
   This CL restores it back.

See #79

Signed-off-by: pavan142 <pa1tirumani@gmail.com>